### PR TITLE
Terminal reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,6 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -108,12 +107,6 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +33,133 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -45,6 +174,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,10 +233,190 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termplt"
 version = "0.1.0"
 dependencies = [
+ "crossterm",
  "libc",
  "nix",
  "rgb",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-crossterm = { version = "0.29.0", features = [ "event-stream" ] }
+crossterm = "0.29.0"
 libc = "0.2.172"
 nix = { version = "0.30.1", features = [ "ioctl" ] }
 rgb = "0.8.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+crossterm = { version = "0.29.0", features = [ "event-stream" ] }
 libc = "0.2.172"
 nix = { version = "0.30.1", features = [ "ioctl" ] }
 rgb = "0.8.50"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use rgb::RGB8;
 
 mod kitty_graphics;
+mod terminal_commands;
 
 const RED: RGB8 = RGB8 { r: 255, g: 0, b: 0 };
 const GREEN: RGB8 = RGB8 { r: 0, g: 255, b: 0 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ const WHITE: RGB8 = RGB8 {
 const BLACK: RGB8 = RGB8 { r: 0, g: 0, b: 0 };
 
 fn main() {
+    terminal_commands::responses::read_command().unwrap();
+}
+
+fn test_printin() {
     let img_path = "/home/edcarney/wallpapers/pixel-night-city.png";
 
     kitty_graphics::rgba_imgs::print_square(50, GREEN.with_alpha(25)).unwrap();

--- a/src/terminal_commands.rs
+++ b/src/terminal_commands.rs
@@ -1,0 +1,1 @@
+mod responses;

--- a/src/terminal_commands.rs
+++ b/src/terminal_commands.rs
@@ -1,1 +1,1 @@
-mod responses;
+pub mod responses;

--- a/src/terminal_commands/responses.rs
+++ b/src/terminal_commands/responses.rs
@@ -3,10 +3,9 @@ use std::io::{self, Read, Write};
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-pub fn execute_csi(cmd: &str) -> Result<String> {
-    let resp_start = "\x1b";
-    let resp_end = "R";
-    let cmd = String::from("\x1b[") + cmd;
+pub fn execute_csi(cmd: &str, resp_end: &str) -> Result<String> {
+    let resp_start = "\x1b[";
+    let cmd = String::from(resp_start) + cmd;
     let resp = execute_and_read(&cmd, resp_start, resp_end)?;
     resp_to_str(resp, resp_start, resp_end)
 }
@@ -65,11 +64,14 @@ fn resp_to_str(resp: Vec<u8>, resp_start: &str, resp_end: &str) -> Result<String
 }
 
 pub fn read_command() -> Result<()> {
-    let resp = execute_csi("6n")?;
+    let resp = execute_csi("6n", "R")?;
+    println!("CSI Resp: {resp:?}");
+
+    let resp = execute_csi("c", "c")?;
     println!("CSI Resp: {resp:?}");
 
     let resp = execute_kitty("i=31,s=1,v=1,a=q,d=t,f=24;AAAA")?;
     println!("Kitty Resp: {resp:?}");
+
     Ok(())
 }
-

--- a/src/terminal_commands/responses.rs
+++ b/src/terminal_commands/responses.rs
@@ -1,0 +1,32 @@
+use crossterm::{event, terminal};
+use std::io::{self, Read, Write};
+
+pub fn read_command() -> Result<(), Box<dyn std::error::Error>> {
+    terminal::enable_raw_mode()?;
+
+    let mut stdout = std::io::stdout().lock();
+
+    write!(stdout, "\x1b[6n")?;
+
+    stdout.flush()?;
+
+    let mut stdin = std::io::stdin().lock();
+    let mut buf = Vec::<u8>::new();
+    let mut byte_buf = [0u8; 1];
+
+    loop {
+        match stdin.read_exact(&mut byte_buf) {
+            Ok(_) => {
+                buf.push(byte_buf[0]);
+
+                if buf.len() > 3 && buf.ends_with(b"R") {
+                    break;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(())
+}
+

--- a/src/terminal_commands/responses.rs
+++ b/src/terminal_commands/responses.rs
@@ -119,8 +119,8 @@ fn execute_and_read<T: TermCommand>(cmd: &T) -> Result<Vec<u8>> {
     });
 
     std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_secs(3));
-        tx2.send(Vec::new()).unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        tx2.send(Vec::new()).unwrap_or_else(|_| ());
     });
 
     {

--- a/src/terminal_commands/responses.rs
+++ b/src/terminal_commands/responses.rs
@@ -13,18 +13,18 @@ const KITTY_END: &str = "\x1b\\";
 pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 trait TermCommand {
-    fn cmd(&self) -> String;
-    fn req_start(&self) -> String {
-        String::from("")
+    fn cmd(&self) -> &str;
+    fn req_start(&self) -> &str {
+        ""
     }
-    fn req_end(&self) -> String {
-        String::from("")
+    fn req_end(&self) -> &str {
+        ""
     }
-    fn res_start(&self) -> String {
-        String::from("")
+    fn res_start(&self) -> &str {
+        ""
     }
-    fn res_end(&self) -> String {
-        String::from("")
+    fn res_end(&self) -> &str {
+        ""
     }
     fn generate_request(&self) -> Vec<u8> {
         let mut req = Vec::new();
@@ -35,47 +35,45 @@ trait TermCommand {
     }
 }
 
-#[derive(Clone)]
 struct KittyCommand {
     cmd: String,
 }
 
 impl TermCommand for KittyCommand {
-    fn cmd(&self) -> String {
-        self.cmd.clone()
+    fn cmd(&self) -> &str {
+        &self.cmd
     }
-    fn req_start(&self) -> String {
-        String::from(KITTY_START)
+    fn req_start(&self) -> &str {
+        KITTY_START
     }
-    fn req_end(&self) -> String {
-        String::from(KITTY_END)
+    fn req_end(&self) -> &str {
+        KITTY_END
     }
-    fn res_start(&self) -> String {
-        String::from(KITTY_START)
+    fn res_start(&self) -> &str {
+        KITTY_START
     }
-    fn res_end(&self) -> String {
-        String::from(KITTY_END)
+    fn res_end(&self) -> &str {
+        KITTY_END
     }
 }
 
-#[derive(Clone)]
 struct CsiCommand {
     cmd: String,
     res_end: String,
 }
 
 impl TermCommand for CsiCommand {
-    fn cmd(&self) -> String {
-        self.cmd.clone()
+    fn cmd(&self) -> &str {
+        &self.cmd
     }
-    fn req_start(&self) -> String {
-        String::from(CSI_START)
+    fn req_start(&self) -> &str {
+        CSI_START
     }
-    fn res_start(&self) -> String {
-        String::from(CSI_START)
+    fn res_start(&self) -> &str {
+        CSI_START
     }
-    fn res_end(&self) -> String {
-        self.res_end.clone()
+    fn res_end(&self) -> &str {
+        &self.res_end
     }
 }
 
@@ -93,8 +91,8 @@ impl fmt::Display for TerminalCommandError {
 impl Error for TerminalCommandError {}
 
 fn execute_and_read<T: TermCommand>(cmd: &T) -> Result<Vec<u8>> {
-    let res_start = cmd.res_start().into_bytes();
-    let res_end = cmd.res_end().into_bytes();
+    let res_start = cmd.res_start().as_bytes();
+    let res_end = cmd.res_end().as_bytes();
 
     terminal::enable_raw_mode()?;
 
@@ -135,7 +133,7 @@ fn execute_and_read<T: TermCommand>(cmd: &T) -> Result<Vec<u8>> {
         Ok(buf)
     } else {
         Err(Box::new(TerminalCommandError {
-            failed_cmd: cmd.cmd(),
+            failed_cmd: cmd.cmd().into(),
         }))
     }
 }
@@ -147,7 +145,7 @@ fn resp_to_str<T: TermCommand>(resp: &[u8], cmd: &T) -> Result<String> {
         Ok(String::from_utf8(resp[start..end].to_vec())?)
     } else {
         Err(Box::new(TerminalCommandError {
-            failed_cmd: cmd.cmd(),
+            failed_cmd: cmd.cmd().into(),
         }))
     }
 }

--- a/src/terminal_commands/responses.rs
+++ b/src/terminal_commands/responses.rs
@@ -5,7 +5,6 @@ use std::{
     io::{self, Read, Write},
 };
 
-const ESC: &str = "\x1b";
 const CSI_START: &str = "\x1b[";
 const KITTY_START: &str = "\x1b_G";
 const KITTY_END: &str = "\x1b\\";
@@ -158,3 +157,4 @@ pub fn read_command() -> Result<()> {
 
     Ok(())
 }
+


### PR DESCRIPTION
Adds initial implementation for getting responses from terminal commands (both CSI and Kitty). Able to send commands and wait for a specified timeout for a response.

Note that running the project in Ghostty should output a response to the Kitty query command with 'Ok', while in Kitty term the same command outputs an ERNO. I believe this is potentially an issue with Ghostty.