### PR TITLE
Adds and Implements Drawable Trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,13 +44,13 @@ fn main() {
         .map(|x| Point::new(x, x * x))
         .collect::<Vec<Point<_>>>();
 
-    let bytes_1 = TerminalCanvas::new(width + 100, height + 100, colors::BLACK)
+    let bytes_1 = TerminalCanvas::new(width + 100, height + 100, colors::WHITE)
         .with_buffer(BufferType::Uniform(15))
         .with_graph(
             Graph::new().with_series(Series::new(&points).with_marker_style(
                 MarkerStyle::HollowSquare {
                     size: 5,
-                    color: colors::WHITE,
+                    color: colors::BLACK,
                 },
             )),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use termplt::{
         canvas::{BufferType, TerminalCanvas},
         colors,
         graph::Graph,
+        marker::MarkerStyle,
         point::Point,
         series::Series,
     },
@@ -42,9 +43,17 @@ fn main() {
     let points = (0..=20)
         .map(|x| Point::new(x, x * x))
         .collect::<Vec<Point<_>>>();
-    let bytes_1 = TerminalCanvas::new(width, height, colors::BLACK)
+
+    let bytes_1 = TerminalCanvas::new(width + 100, height + 100, colors::BLACK)
         .with_buffer(BufferType::Uniform(15))
-        .with_graph(Graph::new().with_series(Series::new(&points)))
+        .with_graph(
+            Graph::new().with_series(Series::new(&points).with_marker_style(
+                MarkerStyle::HollowSquare {
+                    size: 5,
+                    color: colors::WHITE,
+                },
+            )),
+        )
         .draw()
         .unwrap()
         .get_bytes();
@@ -63,7 +72,10 @@ fn main() {
         .unwrap()
         .get_bytes();
 
-    let format = PixelFormat::Rgb { width, height };
+    let format = PixelFormat::Rgb {
+        width: width + 100,
+        height: height + 100,
+    };
     let transmission = Transmission::Direct(bytes_1);
     Image::new(format, transmission).unwrap().display().unwrap();
     println!();

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -3,6 +3,7 @@ pub mod colors;
 pub mod common;
 pub mod graph;
 pub mod limits;
+pub mod line;
+pub mod marker;
 pub mod point;
 pub mod series;
-pub mod styles;

--- a/src/plotting/canvas.rs
+++ b/src/plotting/canvas.rs
@@ -1,12 +1,12 @@
 use std::{rc::Rc, sync::Mutex};
 
 use super::{
-    common::{Drawable, Graphable},
+    common::{DrawPositioning, Drawable, Graphable},
     graph::Graph,
     limits::Limits,
+    marker::MarkerStyle,
     point::Point,
     series::Series,
-    styles::MarkerStyle,
 };
 use crate::common::Result;
 use rgb::RGB8;
@@ -140,9 +140,11 @@ where
 
         for series in scaled_graph.data() {
             for point in series.data() {
-                TerminalCanvas::<T>::get_marker_mask(point, series.marker_style())
+                series
+                    .marker_style()
+                    .get_mask(DrawPositioning::CenteredAt(point.clone()))?
                     .iter()
-                    .for_each(|x| self.canvas.set_pixels(&x.0, &x.1));
+                    .for_each(|mask| self.canvas.set_pixels(&mask.points, &mask.color));
             }
         }
 

--- a/src/plotting/common.rs
+++ b/src/plotting/common.rs
@@ -39,11 +39,6 @@ impl<T> Graphable for T where
 {
 }
 
-pub enum DrawPositioning {
-    CenteredAt(Point<u32>),
-    Between(Point<u32>, Point<u32>),
-}
-
 pub struct MaskPoints {
     pub points: Vec<Point<u32>>,
     pub color: RGB8,
@@ -52,5 +47,5 @@ pub struct MaskPoints {
 pub trait Drawable {
     fn bounding_width(&self) -> u32;
     fn bounding_height(&self) -> u32;
-    fn get_mask(&self, pos: DrawPositioning) -> Result<Vec<MaskPoints>>;
+    fn get_mask(&self) -> Result<Vec<MaskPoints>>;
 }

--- a/src/plotting/common.rs
+++ b/src/plotting/common.rs
@@ -3,6 +3,12 @@ use std::{
     ops::{Add, Div, Mul, Sub},
 };
 
+use rgb::RGB8;
+
+use crate::common::Result;
+
+use super::point::Point;
+
 pub trait Graphable:
     PartialOrd
     + Into<f64>
@@ -33,7 +39,18 @@ impl<T> Graphable for T where
 {
 }
 
+pub enum DrawPositioning {
+    CenteredAt(Point<u32>),
+    Between(Point<u32>, Point<u32>),
+}
+
+pub struct MaskPoints {
+    pub points: Vec<Point<u32>>,
+    pub color: RGB8,
+}
+
 pub trait Drawable {
     fn bounding_width(&self) -> u32;
     fn bounding_height(&self) -> u32;
+    fn get_mask(&self, pos: DrawPositioning) -> Result<Vec<MaskPoints>>;
 }

--- a/src/plotting/graph.rs
+++ b/src/plotting/graph.rs
@@ -1,15 +1,18 @@
 use super::{
-    common::Graphable,
+    common::{Drawable, Graphable, MaskPoints},
     limits::Limits,
+    line::{Line, LineStyle},
     point::{Point, PointCollection},
     series::Series,
 };
+use crate::common::Result;
 
 // TODO: implement items like: axis inclusion, grid lines, legends, etc.
 #[derive(Debug)]
 pub struct Graph<T: Graphable> {
     data: Vec<Series<T>>,
     limits: Option<Limits<T>>,
+    //xy_axes: (Option<Line>, Option<Line>),
 }
 
 impl<T: Graphable> Graph<T> {
@@ -17,6 +20,7 @@ impl<T: Graphable> Graph<T> {
         Graph {
             data: vec![],
             limits: None,
+            //xy_axes: (None, None),
         }
     }
 
@@ -100,6 +104,28 @@ impl<T: Graphable> Graph<T> {
             data: scaled_data,
             limits: Some(limits),
         }
+    }
+}
+
+impl Drawable for Graph<u32> {
+    fn bounding_width(&self) -> u32 {
+        self.limits().unwrap().span().0
+    }
+
+    fn bounding_height(&self) -> u32 {
+        self.limits().unwrap().span().1
+    }
+
+    fn get_mask(&self) -> Result<Vec<MaskPoints>> {
+        let mut mask_points = self
+            .data()
+            .iter()
+            .flat_map(|series| series.get_mask().unwrap())
+            .collect::<Vec<_>>();
+
+        // add axes if they are defined
+
+        Ok(mask_points)
     }
 }
 

--- a/src/plotting/graph.rs
+++ b/src/plotting/graph.rs
@@ -96,7 +96,7 @@ impl<T: Graphable> Graph<T> {
                         Point { x, y } + *limits.min()
                     })
                     .collect::<Vec<_>>();
-                Series::new(&scaled_data)
+                series.clone_with(&scaled_data)
             })
             .collect::<Vec<_>>();
 

--- a/src/plotting/line.rs
+++ b/src/plotting/line.rs
@@ -1,18 +1,23 @@
-use super::{colors, common::Drawable, limits::Limits, point::Point};
+use super::{
+    colors,
+    common::{Drawable, MaskPoints},
+    limits::Limits,
+    point::Point,
+};
 use crate::common::Result;
 use rgb::RGB8;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum LineStyle {
-    None,
     Solid { color: RGB8, thickness: u32 },
+    Dashed { color: RGB8, thickness: u32 },
 }
 
 impl LineStyle {
     pub const fn default() -> LineStyle {
         Self::Solid {
             color: colors::WHITE,
-            thickness: 2,
+            thickness: 0,
         }
     }
 
@@ -21,5 +26,129 @@ impl LineStyle {
             color: colors::WHITE,
             thickness,
         }
+    }
+
+    pub fn thickness(&self) -> u32 {
+        match self {
+            LineStyle::Solid {
+                color: _,
+                thickness,
+            } => *thickness,
+            LineStyle::Dashed {
+                color: _,
+                thickness,
+            } => *thickness,
+        }
+    }
+
+    pub fn color(&self) -> RGB8 {
+        match self {
+            LineStyle::Solid {
+                color,
+                thickness: _,
+            } => *color,
+            LineStyle::Dashed {
+                color,
+                thickness: _,
+            } => *color,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LinePositioning {
+    Horizontal { start: Point<u32>, length: u32 },
+    Vertical { start: Point<u32>, length: u32 },
+    BetweenPoints { start: Point<u32>, end: Point<u32> },
+}
+
+#[derive(Debug)]
+pub struct Line {
+    style: LineStyle,
+    positioning: LinePositioning,
+}
+
+impl Line {
+    pub fn new(positioning: LinePositioning, style: LineStyle) -> Line {
+        Line { style, positioning }
+    }
+
+    pub fn default(positioning: LinePositioning) -> Line {
+        Line {
+            style: LineStyle::default(),
+            positioning,
+        }
+    }
+
+    /// Gets bounding limits for the line.
+    pub fn limits(&self) -> Limits<u32> {
+        let thickness = self.style.thickness();
+        let (from, to) = match self.positioning {
+            LinePositioning::Horizontal { start, length } => {
+                let from = start - Point::new(0, thickness);
+                let to = start + Point::new(length, thickness);
+                (from, to)
+            }
+            LinePositioning::Vertical { start, length } => {
+                let from = start - Point::new(thickness, 0);
+                let to = start + Point::new(thickness, length);
+                (from, to)
+            }
+            LinePositioning::BetweenPoints { start, end } => {
+                // for thickness b/w points, assume that the thickness will not go outside the
+                // limits defined by the two points
+                (start, end)
+            }
+        };
+        Limits::new(from, to)
+    }
+
+    // Gets the full point set between the start and end of the line. Note that this does not
+    // take into account empy space for dashed lines.
+    fn full_points(&self) -> Vec<Point<u32>> {
+        match self.positioning {
+            LinePositioning::Vertical {
+                start: _,
+                length: _,
+            }
+            | LinePositioning::Horizontal {
+                start: _,
+                length: _,
+            } => Point::<u32>::limit_range(self.limits()),
+            LinePositioning::BetweenPoints { start, end } => {
+                todo!()
+            }
+        }
+    }
+}
+
+impl Drawable for Line {
+    fn bounding_height(&self) -> u32 {
+        let limits = self.limits();
+        (*limits.max() - *limits.min()).y
+    }
+
+    fn bounding_width(&self) -> u32 {
+        let limits = self.limits();
+        (*limits.max() - *limits.min()).x
+    }
+
+    fn get_mask(&self) -> Result<Vec<MaskPoints>> {
+        let mask_points = match self.style {
+            LineStyle::Solid {
+                color,
+                thickness: _,
+            } => {
+                vec![MaskPoints {
+                    points: self.full_points(),
+                    color: color.clone(),
+                }]
+            }
+            LineStyle::Dashed {
+                color,
+                thickness: _,
+            } => todo!(),
+        };
+        Ok(mask_points)
     }
 }

--- a/src/plotting/line.rs
+++ b/src/plotting/line.rs
@@ -1,0 +1,25 @@
+use super::{colors, common::Drawable, limits::Limits, point::Point};
+use crate::common::Result;
+use rgb::RGB8;
+
+#[derive(Debug, PartialEq)]
+pub enum LineStyle {
+    None,
+    Solid { color: RGB8, thickness: u32 },
+}
+
+impl LineStyle {
+    pub const fn default() -> LineStyle {
+        Self::Solid {
+            color: colors::WHITE,
+            thickness: 2,
+        }
+    }
+
+    pub const fn default_with_thickness(thickness: u32) -> LineStyle {
+        Self::Solid {
+            color: colors::WHITE,
+            thickness,
+        }
+    }
+}

--- a/src/plotting/marker.rs
+++ b/src/plotting/marker.rs
@@ -1,93 +1,114 @@
 use super::{
     colors,
-    common::{DrawPositioning, Drawable, MaskPoints},
-    line::LineStyle,
+    common::{Drawable, MaskPoints},
+    limits::Limits,
     point::Point,
 };
 use crate::common::Result;
 use rgb::RGB8;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum MarkerStyle {
-    FilledSquare {
-        line_style: Option<LineStyle>,
-        color: RGB8,
-        size: u32,
-    },
-    HollowSquare {
-        line_style: LineStyle,
-        size: u32,
-    },
+    FilledSquare { size: u32, color: RGB8 },
+    HollowSquare { size: u32, color: RGB8 },
+}
+
+#[derive(Debug)]
+pub struct Marker {
+    style: MarkerStyle,
+    center: Point<u32>,
 }
 
 impl MarkerStyle {
-    pub const fn default() -> MarkerStyle {
-        Self::FilledSquare {
-            line_style: None,
-            color: colors::WHITE,
+    pub fn default() -> MarkerStyle {
+        MarkerStyle::FilledSquare {
             size: 0,
+            color: colors::WHITE,
         }
     }
 
-    pub const fn default_with_size(size: u32) -> MarkerStyle {
-        Self::FilledSquare {
-            line_style: None,
-            color: colors::WHITE,
-            size,
+    pub fn size(&self) -> u32 {
+        match self {
+            MarkerStyle::FilledSquare { size, color: _ } => *size,
+            MarkerStyle::HollowSquare { size, color: _ } => *size,
         }
     }
 }
 
-impl Drawable for MarkerStyle {
+impl Marker {
+    pub fn new(center: Point<u32>, style: MarkerStyle) -> Marker {
+        Marker { center, style }
+    }
+
+    pub fn limits(&self) -> Limits<u32> {
+        let size = self.style.size();
+        Limits::new(self.center - size, self.center + size)
+    }
+
+    pub fn style(&self) -> &MarkerStyle {
+        &self.style
+    }
+
+    pub fn center(&self) -> &Point<u32> {
+        &self.center
+    }
+}
+
+impl Drawable for Marker {
     fn bounding_width(&self) -> u32 {
-        match self {
-            Self::FilledSquare {
-                line_style: _,
-                color: _,
-                size,
-            } => size.clone(),
-            Self::HollowSquare {
-                line_style: _,
-                size,
-            } => size.clone(),
-        }
+        self.style.size()
     }
 
     fn bounding_height(&self) -> u32 {
-        match self {
-            Self::FilledSquare {
-                line_style: _,
-                color: _,
-                size,
-            } => size.clone(),
-            Self::HollowSquare {
-                line_style: _,
-                size,
-            } => size.clone(),
-        }
+        self.style.size()
     }
 
-    fn get_mask(&self, pos: DrawPositioning) -> Result<Vec<MaskPoints>> {
-        let mask_points = match pos {
-            DrawPositioning::CenteredAt(center) => match self {
-                MarkerStyle::FilledSquare {
-                    line_style,
-                    color,
-                    size,
-                } => {
-                    let points = (center.x - size..=center.x + size)
-                        .flat_map(|x| {
-                            (center.y - size..=center.y + size).map(move |y| Point { x, y })
-                        })
-                        .collect::<Vec<Point<u32>>>();
-                    vec![MaskPoints {
-                        points,
+    fn get_mask(&self) -> Result<Vec<MaskPoints>> {
+        let mask_points = match self.style {
+            MarkerStyle::FilledSquare { color, size: _ } => {
+                let limits = self.limits();
+                let points = Point::<u32>::limit_range(limits);
+                vec![MaskPoints {
+                    points,
+                    color: color.clone(),
+                }]
+            }
+            MarkerStyle::HollowSquare { color, size } => {
+                let top = Point::<u32>::range(
+                    &Point::new(self.center.x - size, self.center.y + size),
+                    &Point::new(self.center.x + size, self.center.y + size),
+                );
+                let bottom = Point::<u32>::range(
+                    &Point::new(self.center.x - size, self.center.y - size),
+                    &Point::new(self.center.x + size, self.center.y - size),
+                );
+                let right = Point::<u32>::range(
+                    &Point::new(self.center.x + size, self.center.y - size),
+                    &Point::new(self.center.x + size, self.center.y + size),
+                );
+                let left = Point::<u32>::range(
+                    &Point::new(self.center.x - size, self.center.y - size),
+                    &Point::new(self.center.x - size, self.center.y + size),
+                );
+                vec![
+                    MaskPoints {
+                        points: top,
                         color: color.clone(),
-                    }]
-                }
-                _ => panic!("Not implemented!"),
-            },
-            _ => panic!("Not implemented!"),
+                    },
+                    MaskPoints {
+                        points: bottom,
+                        color: color.clone(),
+                    },
+                    MaskPoints {
+                        points: right,
+                        color: color.clone(),
+                    },
+                    MaskPoints {
+                        points: left,
+                        color: color.clone(),
+                    },
+                ]
+            }
         };
         Ok(mask_points)
     }

--- a/src/plotting/marker.rs
+++ b/src/plotting/marker.rs
@@ -1,4 +1,10 @@
-use super::{colors, common::Drawable, limits::Limits, point::Point};
+use super::{
+    colors,
+    common::{DrawPositioning, Drawable, MaskPoints},
+    line::LineStyle,
+    point::Point,
+};
+use crate::common::Result;
 use rgb::RGB8;
 
 #[derive(Debug, PartialEq)]
@@ -19,7 +25,7 @@ impl MarkerStyle {
         Self::FilledSquare {
             line_style: None,
             color: colors::WHITE,
-            size: 1,
+            size: 0,
         }
     }
 
@@ -60,26 +66,29 @@ impl Drawable for MarkerStyle {
             } => size.clone(),
         }
     }
-}
 
-#[derive(Debug, PartialEq)]
-pub enum LineStyle {
-    None,
-    Solid { color: RGB8, thickness: u32 },
-}
-
-impl LineStyle {
-    pub const fn default() -> LineStyle {
-        Self::Solid {
-            color: colors::WHITE,
-            thickness: 2,
-        }
-    }
-
-    pub const fn default_with_thickness(thickness: u32) -> LineStyle {
-        Self::Solid {
-            color: colors::WHITE,
-            thickness,
-        }
+    fn get_mask(&self, pos: DrawPositioning) -> Result<Vec<MaskPoints>> {
+        let mask_points = match pos {
+            DrawPositioning::CenteredAt(center) => match self {
+                MarkerStyle::FilledSquare {
+                    line_style,
+                    color,
+                    size,
+                } => {
+                    let points = (center.x - size..=center.x + size)
+                        .flat_map(|x| {
+                            (center.y - size..=center.y + size).map(move |y| Point { x, y })
+                        })
+                        .collect::<Vec<Point<u32>>>();
+                    vec![MaskPoints {
+                        points,
+                        color: color.clone(),
+                    }]
+                }
+                _ => panic!("Not implemented!"),
+            },
+            _ => panic!("Not implemented!"),
+        };
+        Ok(mask_points)
     }
 }

--- a/src/plotting/marker.rs
+++ b/src/plotting/marker.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::common::Result;
 use rgb::RGB8;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub enum MarkerStyle {
     FilledSquare { size: u32, color: RGB8 },
     HollowSquare { size: u32, color: RGB8 },

--- a/src/plotting/point.rs
+++ b/src/plotting/point.rs
@@ -42,6 +42,27 @@ pub struct Point<T: Graphable> {
     pub y: T,
 }
 
+impl<T> Point<T>
+where
+    T: Graphable + Into<u32>,
+{
+    /// Generates the set of points between the start and end (inclusive).
+    pub fn range(from: &Point<T>, to: &Point<T>) -> Vec<Point<u32>> {
+        let from_x: u32 = from.x.into();
+        let from_y: u32 = from.y.into();
+        let to_x: u32 = to.x.into();
+        let to_y: u32 = to.y.into();
+        (from_x..=to_x)
+            .flat_map(|x| (from_y..=to_y).map(move |y| Point::new(x, y)))
+            .collect()
+    }
+
+    /// Generates the set of points between the limits min/max (inclusive).
+    pub fn limit_range(limits: Limits<T>) -> Vec<Point<u32>> {
+        Point::<T>::range(limits.min(), limits.max())
+    }
+}
+
 impl<T: Graphable> Point<T> {
     pub fn new(x: T, y: T) -> Point<T> {
         Point { x, y }

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -1,8 +1,4 @@
-use super::{
-    common::Graphable,
-    point::Point,
-    styles::{LineStyle, MarkerStyle},
-};
+use super::{common::Graphable, line::LineStyle, marker::MarkerStyle, point::Point};
 use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Debug)]

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -1,11 +1,17 @@
-use super::{common::Graphable, line::LineStyle, marker::MarkerStyle, point::Point};
+use super::{
+    common::{Drawable, Graphable, MaskPoints},
+    line::{Line, LinePositioning, LineStyle},
+    marker::{Marker, MarkerStyle},
+    point::{Point, PointCollection},
+};
+use crate::common::Result;
 use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Debug)]
 pub struct Series<T: Graphable> {
     data: Vec<Point<T>>,
     marker_style: MarkerStyle,
-    line_style: LineStyle,
+    line_style: Option<LineStyle>,
 }
 
 impl<T: Graphable> Series<T> {
@@ -17,7 +23,7 @@ impl<T: Graphable> Series<T> {
         Series {
             data: Vec::from(data),
             marker_style: MarkerStyle::default(),
-            line_style: LineStyle::None,
+            line_style: None,
         }
     }
 
@@ -29,18 +35,58 @@ impl<T: Graphable> Series<T> {
         &self.marker_style
     }
 
-    pub fn line_style(&self) -> &LineStyle {
+    pub fn line_style(&self) -> &Option<LineStyle> {
         &self.line_style
     }
 
-    pub fn with_marker(mut self, marker_style: MarkerStyle) -> Self {
+    pub fn with_marker_style(mut self, marker_style: MarkerStyle) -> Self {
         self.marker_style = marker_style;
         self
     }
 
-    pub fn with_line(mut self, line_style: LineStyle) -> Self {
-        self.line_style = line_style;
+    pub fn with_line_style(mut self, line_style: LineStyle) -> Self {
+        self.line_style = Some(line_style);
         self
+    }
+}
+
+impl Drawable for Series<u32> {
+    fn bounding_width(&self) -> u32 {
+        self.data().limits().unwrap().span().0
+    }
+
+    fn bounding_height(&self) -> u32 {
+        self.data().limits().unwrap().span().1
+    }
+
+    fn get_mask(&self) -> Result<Vec<MaskPoints>> {
+        let mut mask_points = self
+            .data()
+            .iter()
+            .flat_map(|&p| {
+                Marker::new(p.clone(), self.marker_style.clone())
+                    .get_mask()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        // add lines if line styling is present
+        if let Some(line_style) = &self.line_style {
+            let mut lines = Vec::<Line>::with_capacity(self.data.len());
+            for i in 0..self.data.len() - 1 {
+                let start = self.data[i];
+                let end = self.data[i + 1];
+                let pos = LinePositioning::BetweenPoints { start, end };
+                lines.push(Line::new(pos, line_style.clone()));
+            }
+            let line_mask_points = lines
+                .iter()
+                .flat_map(|line| line.get_mask().unwrap())
+                .collect::<Vec<_>>();
+            mask_points.extend(line_mask_points);
+        };
+
+        Ok(mask_points)
     }
 }
 

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -27,6 +27,14 @@ impl<T: Graphable> Series<T> {
         }
     }
 
+    pub fn clone_with<U: Graphable>(&self, data: &[Point<U>]) -> Series<U> {
+        Series {
+            data: Vec::from(data),
+            marker_style: self.marker_style.clone(),
+            line_style: self.line_style.clone(),
+        }
+    }
+
     pub fn data(&self) -> &[Point<T>] {
         &self.data
     }


### PR DESCRIPTION
Adds a drawable trait and dedicated types for marker and line. Marker, line, series, and graph all implement drawable and use their child type's drawable implementation. Simplifies drawing for the canvas since it just call the underlying method for the graph.