### PR TITLE
Update graphable

### DIFF
--- a/src/kitty_graphics/encoding.rs
+++ b/src/kitty_graphics/encoding.rs
@@ -70,7 +70,7 @@ mod tests {
     fn encode_1_byte() {
         let text = b"M";
         let enc_bytes = read_bytes_to_b64(text).expect("Failed to encode text");
-        let enc_text = str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
+        let enc_text = std::str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
         assert_eq!(enc_text.len(), 2, "1 byte should be 2 base64 values");
         assert_eq!(enc_text, "TQ");
     }
@@ -79,7 +79,7 @@ mod tests {
     fn encode_2_bytes() {
         let text = b"Ma";
         let enc_bytes = read_bytes_to_b64(text).expect("Failed to encode text");
-        let enc_text = str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
+        let enc_text = std::str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
         assert_eq!(enc_text.len(), 3, "2 bytes should be 3 base64 values");
         assert_eq!(enc_text, "TWE");
     }
@@ -88,7 +88,7 @@ mod tests {
     fn encode_3_bytes() {
         let text = b"Man";
         let enc_bytes = read_bytes_to_b64(text).expect("Failed to encode text");
-        let enc_text = str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
+        let enc_text = std::str::from_utf8(&enc_bytes).expect("Encoded text is invalid UTF-8");
         assert_eq!(enc_text.len(), 4, "3 bytes should be 4 base64 values");
         assert_eq!(enc_text, "TWFu");
     }

--- a/src/plotting/canvas.rs
+++ b/src/plotting/canvas.rs
@@ -2,7 +2,6 @@ use super::{
     common::{Drawable, FloatConvertable, Graphable},
     graph::Graph,
     limits::Limits,
-    marker::MarkerStyle,
     point::Point,
 };
 use crate::common::Result;
@@ -132,7 +131,6 @@ where
         self.graph
             .as_ref()
             .unwrap()
-            .convert_to_f64()
             .scale(canvas_limits)
             .get_mask()?
             .iter()

--- a/src/plotting/canvas.rs
+++ b/src/plotting/canvas.rs
@@ -1,5 +1,5 @@
 use super::{
-    common::{Drawable, Graphable},
+    common::{Drawable, FloatConvertable, Graphable},
     graph::Graph,
     limits::Limits,
     marker::MarkerStyle,
@@ -128,11 +128,12 @@ where
     }
 
     pub fn draw(mut self) -> Result<Self> {
-        let canvas_limits = self.get_drawable_limits();
+        let canvas_limits = self.get_drawable_limits().convert_to_f64();
         self.graph
             .as_ref()
             .unwrap()
-            .scale(canvas_limits, f64::to_int_unchecked)
+            .convert_to_f64()
+            .scale(canvas_limits)
             .get_mask()?
             .iter()
             .for_each(|mask| self.canvas.set_pixels(&mask.points, &mask.color));

--- a/src/plotting/common.rs
+++ b/src/plotting/common.rs
@@ -49,3 +49,36 @@ pub trait Drawable {
     fn bounding_height(&self) -> u32;
     fn get_mask(&self) -> Result<Vec<MaskPoints>>;
 }
+
+pub trait Convertable<U> {
+    type ConvertTo;
+    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo;
+}
+
+impl<T: Graphable, U: Graphable> Convertable<U> for T {
+    type ConvertTo = U;
+    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+        let value: f64 = self.clone().into();
+        unsafe { convert_fn(value) }
+    }
+}
+
+pub trait IntConvertable: Convertable<u32> {
+    fn convert_to_u32(&self) -> Self::ConvertTo;
+}
+
+impl<T: Convertable<u32>> IntConvertable for T {
+    fn convert_to_u32(&self) -> Self::ConvertTo {
+        self.convert_to(f64::to_int_unchecked)
+    }
+}
+
+pub trait FloatConvertable: Convertable<f64> {
+    fn convert_to_f64(&self) -> Self::ConvertTo;
+}
+
+impl<T: Convertable<f64>> FloatConvertable for T {
+    fn convert_to_f64(&self) -> Self::ConvertTo {
+        self.convert_to(f64::from)
+    }
+}

--- a/src/plotting/common.rs
+++ b/src/plotting/common.rs
@@ -63,11 +63,11 @@ impl<T: Graphable, U: Graphable> Convertable<U> for T {
     }
 }
 
-pub trait IntConvertable: Convertable<u32> {
+pub trait UIntConvertable: Convertable<u32> {
     fn convert_to_u32(&self) -> Self::ConvertTo;
 }
 
-impl<T: Convertable<u32>> IntConvertable for T {
+impl<T: Convertable<u32>> UIntConvertable for T {
     fn convert_to_u32(&self) -> Self::ConvertTo {
         self.convert_to(f64::to_int_unchecked)
     }

--- a/src/plotting/graph.rs
+++ b/src/plotting/graph.rs
@@ -1,7 +1,7 @@
 use super::{
     common::{Convertable, Drawable, FloatConvertable, Graphable, MaskPoints, UIntConvertable},
     limits::Limits,
-    line::{Line, LineStyle},
+    line::Line,
     point::{Point, PointCollection},
     series::Series,
 };
@@ -68,14 +68,14 @@ impl<T: Graphable> Graph<T> {
             .limits()
     }
 
-    pub fn scale(mut self, limits: Limits<T>) -> Graph<f64> {
+    pub fn scale(&self, limits: Limits<f64>) -> Graph<f64> {
         let old_limits = self
             .limits()
             .expect("Cannot scale an empty graph")
             .convert_to_f64();
         let (old_span_x, old_span_y) = old_limits.span();
 
-        let new_limits = limits.convert_to_f64();
+        let new_limits = limits;
         let (new_span_x, new_span_y) = new_limits.span();
 
         let x_factor = new_span_x / old_span_x;
@@ -93,12 +93,12 @@ impl<T: Graphable> Graph<T> {
             })
             .collect::<Vec<_>>();
 
-        let x_axis = match self.x_axis.take() {
+        let x_axis = match &self.x_axis {
             None => None,
             Some(line) => Some(line.convert_to_f64()),
         };
 
-        let y_axis = match self.y_axis.take() {
+        let y_axis = match &self.y_axis {
             None => None,
             Some(line) => Some(line.convert_to_f64()),
         };

--- a/src/plotting/limits.rs
+++ b/src/plotting/limits.rs
@@ -1,9 +1,22 @@
-use super::{common::Graphable, point::Point};
+use super::{
+    common::{Convertable, Graphable},
+    point::Point,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Limits<T: Graphable> {
     min: Point<T>,
     max: Point<T>,
+}
+
+impl<T: Graphable, U: Graphable> Convertable<U> for Limits<T> {
+    type ConvertTo = Limits<U>;
+    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+        Limits {
+            min: self.min().convert_to(convert_fn),
+            max: self.min().convert_to(convert_fn),
+        }
+    }
 }
 
 impl<T: Graphable> Limits<T> {

--- a/src/plotting/limits.rs
+++ b/src/plotting/limits.rs
@@ -14,7 +14,7 @@ impl<T: Graphable, U: Graphable> Convertable<U> for Limits<T> {
     fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
         Limits {
             min: self.min().convert_to(convert_fn),
-            max: self.min().convert_to(convert_fn),
+            max: self.max().convert_to(convert_fn),
         }
     }
 }

--- a/src/plotting/line.rs
+++ b/src/plotting/line.rs
@@ -1,6 +1,6 @@
 use super::{
     colors,
-    common::{Drawable, MaskPoints},
+    common::{Drawable, Graphable, MaskPoints},
     limits::Limits,
     point::Point,
 };
@@ -55,25 +55,25 @@ impl LineStyle {
     }
 }
 
-#[derive(Debug)]
-pub enum LinePositioning {
-    Horizontal { start: Point<u32>, length: u32 },
-    Vertical { start: Point<u32>, length: u32 },
-    BetweenPoints { start: Point<u32>, end: Point<u32> },
+#[derive(Debug, Clone)]
+pub enum LinePositioning<T: Graphable> {
+    Horizontal { start: Point<T>, length: T },
+    Vertical { start: Point<T>, length: T },
+    BetweenPoints { start: Point<T>, end: Point<T> },
 }
 
-#[derive(Debug)]
-pub struct Line {
+#[derive(Debug, Clone)]
+pub struct Line<T: Graphable> {
     style: LineStyle,
-    positioning: LinePositioning,
+    positioning: LinePositioning<T>,
 }
 
-impl Line {
-    pub fn new(positioning: LinePositioning, style: LineStyle) -> Line {
+impl<T: Graphable> Line<T> {
+    pub fn new(positioning: LinePositioning<T>, style: LineStyle) -> Line<T> {
         Line { style, positioning }
     }
 
-    pub fn default(positioning: LinePositioning) -> Line {
+    pub fn default(positioning: LinePositioning<T>) -> Line<T> {
         Line {
             style: LineStyle::default(),
             positioning,
@@ -81,7 +81,7 @@ impl Line {
     }
 
     /// Gets bounding limits for the line.
-    pub fn limits(&self) -> Limits<u32> {
+    pub fn limits(&self) -> Limits<T> {
         let thickness = self.style.thickness();
         let (from, to) = match self.positioning {
             LinePositioning::Horizontal { start, length } => {

--- a/src/plotting/point.rs
+++ b/src/plotting/point.rs
@@ -1,5 +1,5 @@
 use super::{
-    common::{Convertable, Graphable, IntConvertable},
+    common::{Convertable, Graphable, UIntConvertable},
     limits::Limits,
 };
 use std::ops::{Add, Div, Mul, Sub};
@@ -56,7 +56,7 @@ impl<T: Graphable, U: Graphable> Convertable<U> for Point<T> {
 
 impl<T> Point<T>
 where
-    T: Graphable + IntConvertable,
+    T: Graphable + UIntConvertable,
 {
     /// Generates the set of points between the start and end (inclusive).
     pub fn range(from: &Point<T>, to: &Point<T>) -> Vec<Point<u32>> {

--- a/src/plotting/point.rs
+++ b/src/plotting/point.rs
@@ -1,11 +1,8 @@
 use super::{
-    common::{Convertable, Graphable},
+    common::{Convertable, Graphable, IntConvertable},
     limits::Limits,
 };
-use std::{
-    convert,
-    ops::{Add, Div, Mul, Sub},
-};
+use std::ops::{Add, Div, Mul, Sub};
 
 pub trait PointCollection<T: Graphable> {
     fn limits(&self) -> Option<Limits<T>>;
@@ -59,16 +56,14 @@ impl<T: Graphable, U: Graphable> Convertable<U> for Point<T> {
 
 impl<T> Point<T>
 where
-    T: Graphable + Into<u32>,
+    T: Graphable + IntConvertable,
 {
     /// Generates the set of points between the start and end (inclusive).
     pub fn range(from: &Point<T>, to: &Point<T>) -> Vec<Point<u32>> {
-        let from_x: u32 = from.x.into();
-        let from_y: u32 = from.y.into();
-        let to_x: u32 = to.x.into();
-        let to_y: u32 = to.y.into();
-        (from_x..=to_x)
-            .flat_map(|x| (from_y..=to_y).map(move |y| Point::new(x, y)))
+        let from = from.convert_to_u32();
+        let to = to.convert_to_u32();
+        (from.x..=to.x)
+            .flat_map(|x| (from.y..=to.y).map(move |y| Point::new(x, y)))
             .collect()
     }
 

--- a/src/plotting/point.rs
+++ b/src/plotting/point.rs
@@ -1,5 +1,11 @@
-use super::{common::Graphable, limits::Limits};
-use std::ops::{Add, Div, Mul, Sub};
+use super::{
+    common::{Convertable, Graphable},
+    limits::Limits,
+};
+use std::{
+    convert,
+    ops::{Add, Div, Mul, Sub},
+};
 
 pub trait PointCollection<T: Graphable> {
     fn limits(&self) -> Option<Limits<T>>;
@@ -40,6 +46,15 @@ impl<T: Graphable> PointCollection<T> for &[Point<T>] {
 pub struct Point<T: Graphable> {
     pub x: T,
     pub y: T,
+}
+
+impl<T: Graphable, U: Graphable> Convertable<U> for Point<T> {
+    type ConvertTo = Point<U>;
+    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+        let x = self.x.convert_to(convert_fn);
+        let y = self.y.convert_to(convert_fn);
+        Point { x, y }
+    }
 }
 
 impl<T> Point<T>

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -1,5 +1,3 @@
-use image::Limits;
-
 use super::{
     common::{Convertable, Drawable, FloatConvertable, Graphable, MaskPoints, UIntConvertable},
     line::{Line, LinePositioning, LineStyle},

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -1,7 +1,7 @@
 use image::Limits;
 
 use super::{
-    common::{Convertable, Drawable, FloatConvertable, Graphable, IntConvertable, MaskPoints},
+    common::{Convertable, Drawable, FloatConvertable, Graphable, MaskPoints, UIntConvertable},
     line::{Line, LinePositioning, LineStyle},
     marker::{Marker, MarkerStyle},
     point::{Point, PointCollection},
@@ -94,7 +94,7 @@ impl<T: Graphable> Series<T> {
     }
 }
 
-impl<T: IntConvertable + Graphable> Drawable for Series<T> {
+impl<T: UIntConvertable + Graphable> Drawable for Series<T> {
     fn bounding_width(&self) -> u32 {
         self.data().limits().unwrap().convert_to_u32().span().0
     }


### PR DESCRIPTION
Multiple improvements to conversions and transforms from mathematical => drawable representations.

Adds common traits for Convertable, UIntConvertable, and FloatConvertable to ease conversions from math to drawing. The u32 type is the common drawable type (all types must be converted to this to be drawn in the terminal canvas). The f64 type is the common mathematical type (all representations for lines, series, graphs must be able to be converted to this). Blanket implementations are done for Graphable -> f64 via f64::from and for Graphable -> u32 via f64::to_int_unchecked.