### PR TITLE
Replace unsafe f64::to_int_unchecked with safe casts

### DIFF
--- a/src/plotting/common.rs
+++ b/src/plotting/common.rs
@@ -48,14 +48,14 @@ pub trait Drawable {
 
 pub trait Convertable<U> {
     type ConvertTo;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo;
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo;
 }
 
 impl<T: Graphable, U: Graphable> Convertable<U> for T {
     type ConvertTo = U;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         let value: f64 = self.clone().into();
-        unsafe { convert_fn(value) }
+        convert_fn(value)
     }
 }
 
@@ -63,9 +63,13 @@ pub trait UIntConvertable: Convertable<u32> {
     fn convert_to_u32(&self) -> Self::ConvertTo;
 }
 
+fn safe_f64_to_u32(v: f64) -> u32 {
+    v.clamp(0.0, u32::MAX as f64) as u32
+}
+
 impl<T: Convertable<u32>> UIntConvertable for T {
     fn convert_to_u32(&self) -> Self::ConvertTo {
-        self.convert_to(f64::to_int_unchecked)
+        self.convert_to(safe_f64_to_u32)
     }
 }
 
@@ -73,9 +77,13 @@ pub trait IntConvertable: Convertable<i32> {
     fn convert_to_i32(&self) -> Self::ConvertTo;
 }
 
+fn safe_f64_to_i32(v: f64) -> i32 {
+    v.clamp(i32::MIN as f64, i32::MAX as f64) as i32
+}
+
 impl<T: Convertable<i32>> IntConvertable for T {
     fn convert_to_i32(&self) -> Self::ConvertTo {
-        self.convert_to(f64::to_int_unchecked)
+        self.convert_to(safe_f64_to_i32)
     }
 }
 

--- a/src/plotting/graph.rs
+++ b/src/plotting/graph.rs
@@ -24,7 +24,7 @@ pub struct Graph<T: Graphable + FloatConvertable> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for Graph<T> {
     type ConvertTo = Graph<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         let data = self
             .data
             .iter()

--- a/src/plotting/graph_limits.rs
+++ b/src/plotting/graph_limits.rs
@@ -69,7 +69,7 @@ where
 
 impl<T: Graphable, U: Graphable> Convertable<U> for GraphLimits<T> {
     type ConvertTo = GraphLimits<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         match &self {
             Self::XOnly { min, max } => GraphLimits::XOnly {
                 min: min.convert_to(convert_fn),

--- a/src/plotting/limits.rs
+++ b/src/plotting/limits.rs
@@ -11,7 +11,7 @@ pub struct Limits<T: Graphable> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for Limits<T> {
     type ConvertTo = Limits<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         Limits {
             min: self.min().convert_to(convert_fn),
             max: self.max().convert_to(convert_fn),

--- a/src/plotting/line.rs
+++ b/src/plotting/line.rs
@@ -67,7 +67,7 @@ pub struct Line<T: Graphable> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for Line<T> {
     type ConvertTo = Line<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         let style = self.style().clone();
         let positioning = self.positioning.convert_to(convert_fn);
         Line { style, positioning }

--- a/src/plotting/line_positioning.rs
+++ b/src/plotting/line_positioning.rs
@@ -36,7 +36,7 @@ impl<T: Graphable> LinePositioning<T> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for LinePositioning<T> {
     type ConvertTo = LinePositioning<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         match &self {
             LinePositioning::Horizontal { start, length } => {
                 let start = start.convert_to(convert_fn);

--- a/src/plotting/point.rs
+++ b/src/plotting/point.rs
@@ -47,7 +47,7 @@ pub struct Point<T: Graphable> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for Point<T> {
     type ConvertTo = Point<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         let x = self.x.convert_to(convert_fn);
         let y = self.y.convert_to(convert_fn);
         Point { x, y }

--- a/src/plotting/series.rs
+++ b/src/plotting/series.rs
@@ -21,7 +21,7 @@ pub struct Series<T: Graphable> {
 
 impl<T: Graphable, U: Graphable> Convertable<U> for Series<T> {
     type ConvertTo = Series<U>;
-    fn convert_to(&self, convert_fn: unsafe fn(f64) -> U) -> Self::ConvertTo {
+    fn convert_to(&self, convert_fn: fn(f64) -> U) -> Self::ConvertTo {
         let data = self
             .data
             .iter()


### PR DESCRIPTION
## Summary
- Replace `f64::to_int_unchecked` (undefined behavior for NaN/Inf/out-of-range) with safe saturating cast helpers using `f64::clamp` + `as`
- Change `Convertable` trait signature from `unsafe fn(f64) -> U` to `fn(f64) -> U` across all 8 implementing files
- Eliminates all `unsafe` code from the plotting subsystem (only remaining `unsafe` is the `ioctl` FFI call in `window_ctrl.rs`)

## Test plan
- [x] All 38 existing unit tests pass
- [x] Verify rendering output is visually unchanged for example graphs in `main.rs`
- [ ] Confirm edge-case data (e.g., single-point series, very large/small float values) renders without panic or corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)